### PR TITLE
Update _rhythm.scss to work with Dart Sass 2

### DIFF
--- a/src/_rhythm.scss
+++ b/src/_rhythm.scss
@@ -1,14 +1,16 @@
+@use "sass:math";
+
 $sass-rhythm: 4 !default;
 $sass-rhythm-root-font-size: 16px !default;
 
 @function sass-rhythm-unitless($number) {
-  @return $number / ($number * 0 + 1);
+  @return math.div($number, $number * 0 + 1);
 }
 
 @function sass-rhythm($multiplier: 1, $offset-pixels: 0) {
-  @return ($multiplier * (($sass-rhythm / sass-rhythm-unitless($sass-rhythm-root-font-size)) * 1rem) + (1rem / sass-rhythm-unitless($sass-rhythm-root-font-size) * $offset-pixels));
+  @return ($multiplier * (math.div($sass-rhythm, sass-rhythm-unitless($sass-rhythm-root-font-size)) * 1rem) + (math.div(1rem, sass-rhythm-unitless($sass-rhythm-root-font-size)) * $offset-pixels));
 }
 
 @function sass-rhythm-relative-root-font-size() {
-  @return (sass-rhythm-unitless($sass-rhythm-root-font-size) / 16) * 100%;
+  @return math.div(sass-rhythm-unitless($sass-rhythm-root-font-size), 16) * 100%;
 }


### PR DESCRIPTION
In this PR the slash division outside of the calc methods is replaced with the math.div function