### PR TITLE
Update _rhythm.scss to work with Dart Sass 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Sass helper functions for maintaining a vertical rhythm in your frontend design.
 
+Since `math.div` is only available in Dart Sass >=1.33 and not LibSass or Ruby Sass (see [the docs](https://sass-lang.com/documentation/breaking-changes/slash-div/)), the newest version of this package is only available for Dart Sass >=1.33. If you need to use this package with older versions of Dart Sass, LibSass or Ruby Sass, feel free to keep using v0.2.0.
+
 ## Install
 ```cli
 yarn add sass-rhythm

--- a/src/_rhythm.scss
+++ b/src/_rhythm.scss
@@ -1,14 +1,16 @@
+@use "sass:math";
+
 $sass-rhythm: 4 !default;
 $sass-rhythm-root-font-size: 16px !default;
 
 @function sass-rhythm-unitless($number) {
-  @return $number / ($number * 0 + 1);
+  @return math.div($number, $number * 0 + 1);
 }
 
 @function sass-rhythm($multiplier: 1, $offset-pixels: 0) {
-  @return ($multiplier * (($sass-rhythm / sass-rhythm-unitless($sass-rhythm-root-font-size)) * 1rem) + (1rem / sass-rhythm-unitless($sass-rhythm-root-font-size) * $offset-pixels));
+  @return ($multiplier * (math.div($sass-rhythm, sass-rhythm-unitless($sass-rhythm-root-font-size)) * 1rem) + (math.div(1rem, sass-rhythm-unitless($sass-rhythm-root-font-size)) * $offset-pixels));
 }
 
 @function sass-rhythm-relative-root-font-size() {
-  @return (sass-rhythm-unitless($sass-rhythm-root-font-size) / 16) * 100%;
+  @return math.div(sass-rhythm-unitless($sass-rhythm-root-font-size), 16) * 100%;
 }


### PR DESCRIPTION
In this PR the slash division outside of the calc methods is replaced with the math.div function